### PR TITLE
add fallback to 'sub' token claim

### DIFF
--- a/auth/oidc/classes/loginflow/authcode.php
+++ b/auth/oidc/classes/loginflow/authcode.php
@@ -371,6 +371,8 @@ class authcode extends base {
                 $upn = $idtoken->claim('upn');
                 if (empty($upn)) {
                     $upn = $idtoken->claim('unique_name');
+                } else if (empty($upn)) {
+                    $upn = $idtoken->claim('sub');
                 }
             }
             $userrec = $DB->count_records_sql('SELECT COUNT(*)


### PR DESCRIPTION
handlelogin() fallsback to 'sub' if 'upn' and 'unique_name' are empty - I think this should happen in handleauthresponse() too.